### PR TITLE
Feature/video block

### DIFF
--- a/partials/blocks/video.php
+++ b/partials/blocks/video.php
@@ -30,7 +30,7 @@ $external_video_platform 	= get_field('external_video_platform');
 # get the ID of the video from the URL (last element)
 $video_url_bits = explode('/', $external_video_url);
 $video_id = end($video_url_bits);
-$video_url = "https://player.vimeo.com/video/". $video_id . "?";
+$video_url = "https://player.vimeo.com/video/". $video_id . "?"; # note that the ? is necessary even when you have no params
 # echo var_dump('video_url', $video_url);
 
 # we replace the $external_video (which was iframe) with our iframe with the video_url 

--- a/partials/blocks/video.php
+++ b/partials/blocks/video.php
@@ -31,7 +31,7 @@ $external_video_platform 	= get_field('external_video_platform');
 $video_url_bits = explode('/', $external_video_url);
 $video_id = end($video_url_bits);
 $video_url = "https://player.vimeo.com/video/". $video_id . "?";
-echo var_dump('video_url', $video_url);
+# echo var_dump('video_url', $video_url);
 
 # we replace the $external_video (which was iframe) with our iframe with the video_url 
 

--- a/partials/blocks/video.php
+++ b/partials/blocks/video.php
@@ -19,7 +19,22 @@ $video_file 				= get_field('video_file');
 $poster_image 				= get_field('poster_image');
 $video_caption 				= get_field('video_caption');
 $external_video 			= get_field('external_video');
+
+# add new ACF for video URL, afterwards we can delete some of these unused ---------------------
+$external_video_url 		= get_field('external_video_url');
+
 $external_video_platform 	= get_field('external_video_platform');
+
+# Note: need to update how translators can 'translate' the video URL for their language -----------------------
+# external_video_url will be the video URL, instead of using the embed code (iframe)
+# get the ID of the video from the URL (last element)
+$video_url_bits = explode('/', $external_video_url);
+$video_id = end($video_url_bits);
+$video_url = "https://player.vimeo.com/video/". $video_id . "?";
+echo var_dump('video_url', $video_url);
+
+# we replace the $external_video (which was iframe) with our iframe with the video_url 
+
 
 ?>
 
@@ -28,7 +43,8 @@ $external_video_platform 	= get_field('external_video_platform');
 		<?php if($external_video) : ?>
 		<div class="video">
 			<div class="external-video">
-				<?php echo $external_video; ?>
+				<!--<?php #echo $external_video; ?> -->
+				<iframe src="<?php echo $video_url; ?>" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 			</div>
 			<span class="with-effect" style="background-image: url(<?php echo $poster_image['url']; ?>)"><span class="play"></span></span>
 		</div>

--- a/partials/blocks/video.php
+++ b/partials/blocks/video.php
@@ -31,9 +31,9 @@ $external_video_platform 	= get_field('external_video_platform');
 $video_url_bits = explode('/', $external_video_url);
 $video_id = end($video_url_bits);
 $video_url = "https://player.vimeo.com/video/". $video_id . "?"; # note that the ? is necessary even when you have no params
-# echo var_dump('video_url', $video_url);
 
-# we replace the $external_video (which was iframe) with our iframe with the video_url 
+# we replace the $external_video (which was the embed code from vimeo, an iframe)
+# with the iframe we create using the video_url 
 
 
 ?>
@@ -43,7 +43,6 @@ $video_url = "https://player.vimeo.com/video/". $video_id . "?"; # note that the
 		<?php if($external_video) : ?>
 		<div class="video">
 			<div class="external-video">
-				<!--<?php #echo $external_video; ?> -->
 				<iframe src="<?php echo $video_url; ?>" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 			</div>
 			<span class="with-effect" style="background-image: url(<?php echo $poster_image['url']; ?>)"><span class="play"></span></span>


### PR DESCRIPTION
New ACF field in the Video block is already created in WordPress and for past videos it's been populated with the Vimeo video URL, so this update shouldn't break any of the video posts.

Need to push this to staging next time we deploy using git....

