### PR TITLE
Notes for annual report css issue

### DIFF
--- a/assets/css/asianlegacylibrary/asianlegacylibrary.css
+++ b/assets/css/asianlegacylibrary/asianlegacylibrary.css
@@ -4,12 +4,39 @@
 */
 .is-style-fill > a,
 .is-style-outline > a {
-  padding: 0.3em; }
+    padding: 0.3em;
+}
 
 .wp-block-buttons .wp-block-button .wp-block-button__link {
-  padding: 0.3em; }
+    padding: 0.3em;
+}
 
 /* adding this for no other reason that to be able to quickly check if updates are working */
 html:not(.home),
 body:not(.home) {
-  /* background-color: aqua;*/ }
+    /* background-color: aqua;*/
+}
+
+/*
+= ANNUAL REPORT
+------------------------------------------------------------------------------------- */
+/* JC added this Jan 20, 2023 // temp fix to stop behavior on all pages except annual report
+-- Get No Format (Drasko) to look at this...
+body > div.content-outer.inner-page-content.page-entry
+styles applied:
+transform: translateX(0px) translateY(100vh) translateZ(0px) rotate(0deg) scale(1, 1);
+*/
+.content-outer:not(.annual-content-holder),
+.content-outer:not(.annual-report) {
+    -webkit-transform: none !important;
+    -moz-transform: none !important;
+    -ms-transform: none !important;
+    -o-transform: none !important;
+    transform: none !important;
+}
+/* end attempted update ---------------- */
+
+/* quick fix for history timeline issue, disappearing when scrolling up */
+body.page-template-tpl_timeline {
+    height: 100% !important;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -9606,10 +9606,15 @@ body.faded:after {
 ------------------------------------------------------------------------------------- */
 /* JC added this Jan 20, 2023 // temp fix to stop behavior on all pages except annual report
 -- Get No Format (Drasko) to look at this...
+body > div.content-outer.inner-page-content.page-entry
+styles applied:
+transform: translateX(0px) translateY(100vh) translateZ(0px) rotate(0deg) scale(1, 1);
 */
 .content-outer:not(.annual-content-holder) {
     transform: none !important;
 }
+/* end attempted update ---------------- */
+
 .annual-report header .holder .logo,
 .annual-report header .holder nav,
 .annual-report header .holder .nav-trigger {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -9601,25 +9601,6 @@ body.faded:after {
     transition: left 0ms, opacity 500ms cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
-/*
-= ANNUAL REPORT
-------------------------------------------------------------------------------------- */
-/* JC added this Jan 20, 2023 // temp fix to stop behavior on all pages except annual report
--- Get No Format (Drasko) to look at this...
-body > div.content-outer.inner-page-content.page-entry
-styles applied:
-transform: translateX(0px) translateY(100vh) translateZ(0px) rotate(0deg) scale(1, 1);
-*/
-.content-outer:not(.annual-content-holder),
-.content-outer:not(.annual-report) {
-    -webkit-transform: none !important;
-    -moz-transform: none !important;
-    -ms-transform: none !important;
-    -o-transform: none !important;
-    transform: none !important;
-}
-/* end attempted update ---------------- */
-
 .annual-report header .holder .logo,
 .annual-report header .holder nav,
 .annual-report header .holder .nav-trigger {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -9610,7 +9610,12 @@ body > div.content-outer.inner-page-content.page-entry
 styles applied:
 transform: translateX(0px) translateY(100vh) translateZ(0px) rotate(0deg) scale(1, 1);
 */
-.content-outer:not(.annual-content-holder) {
+.content-outer:not(.annual-content-holder),
+.content-outer:not(.annual-report) {
+    -webkit-transform: none !important;
+    -moz-transform: none !important;
+    -ms-transform: none !important;
+    -o-transform: none !important;
     transform: none !important;
 }
 /* end attempted update ---------------- */

--- a/partials/blocks/video.php
+++ b/partials/blocks/video.php
@@ -18,7 +18,7 @@ if( !empty($block['className']) ) {
 $video_file 				= get_field('video_file');
 $poster_image 				= get_field('poster_image');
 $video_caption 				= get_field('video_caption');
-$external_video 			= get_field('external_video');
+# $external_video 			= get_field('external_video');
 
 # UPDATED VIDEO field for video block, need to remove the embed iframe field from ACF and from here ------------------
 # add new ACF for video URL, afterwards we can delete some of these unused ---------------------
@@ -40,9 +40,9 @@ $video_url = "https://player.vimeo.com/video/". $video_id . "?"; # note that the
 
 ?>
 
-<section class="<?php echo esc_attr($className); ?> <?php if($external_video) : echo 'external'; else : echo 'local'; endif; ?> <?php echo $external_video_platform; ?>">
+<section class="<?php echo esc_attr($className); ?> <?php if($external_video_url) : echo 'external'; else : echo 'local'; endif; ?> <?php echo $external_video_platform; ?>">
 	<figure class="video-wrapper">
-		<?php if($external_video) : ?>
+		<?php if($external_video_url) : ?>
 		<div class="video">
 			<div class="external-video">
 				<!-- we've replaced the video embed with our own, using a much simpler URL from vimeo, then we build the iframe here

--- a/partials/blocks/video.php
+++ b/partials/blocks/video.php
@@ -20,6 +20,7 @@ $poster_image 				= get_field('poster_image');
 $video_caption 				= get_field('video_caption');
 $external_video 			= get_field('external_video');
 
+# UPDATED VIDEO field for video block, need to remove the embed iframe field from ACF and from here ------------------
 # add new ACF for video URL, afterwards we can delete some of these unused ---------------------
 $external_video_url 		= get_field('external_video_url');
 
@@ -34,7 +35,8 @@ $video_url = "https://player.vimeo.com/video/". $video_id . "?"; # note that the
 
 # we replace the $external_video (which was the embed code from vimeo, an iframe)
 # with the iframe we create using the video_url 
-# THIS IS THE NEW THINGS! and seriously will the submodule in wp engine ever update?
+# ----------------------------------------------------------------------------------------
+
 
 ?>
 
@@ -43,6 +45,8 @@ $video_url = "https://player.vimeo.com/video/". $video_id . "?"; # note that the
 		<?php if($external_video) : ?>
 		<div class="video">
 			<div class="external-video">
+				<!-- we've replaced the video embed with our own, using a much simpler URL from vimeo, then we build the iframe here
+					this makes it much easier for translators and people creating news posts to add video links  -->
 				<iframe src="<?php echo $video_url; ?>" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 			</div>
 			<span class="with-effect" style="background-image: url(<?php echo $poster_image['url']; ?>)"><span class="play"></span></span>


### PR DESCRIPTION
-- transform Y issue from No Format update for Annual Report page template

There seems to be an issue with the recent update for the annual report. When you scroll a transform gets added to the content-outer styles, which is needed for the annual report, but the css is targeting all pages instead of just the annual report. I've added screenshots to show the result...I added a quick fix to main.css which you'll see in the latest commit. This has been pushed to DEV and PROD...

/* JC added this Jan 20, 2023 // temp fix to stop behavior on all pages except annual report
-- Get No Format (Drasko) to look at this...
*/
.content-outer:not(.annual-content-holder) {
    transform: none !important;
}
![issue_from_annual_report](https://user-images.githubusercontent.com/11063469/229562642-c6f1cbd0-ee88-4993-8182-4507ea984f12.png)
