### PR TITLE
CSS fix for Annual Report and History pages

### DIFF
--- a/assets/css/asianlegacylibrary/asianlegacylibrary.css
+++ b/assets/css/asianlegacylibrary/asianlegacylibrary.css
@@ -25,9 +25,11 @@ body:not(.home) {
 body > div.content-outer.inner-page-content.page-entry
 styles applied:
 transform: translateX(0px) translateY(100vh) translateZ(0px) rotate(0deg) scale(1, 1);
+,
+.content-outer:not(.annual-report) 
 */
-.content-outer:not(.annual-content-holder),
-.content-outer:not(.annual-report) {
+
+.content-outer:not(.annual-content-holder) {
     -webkit-transform: none !important;
     -moz-transform: none !important;
     -ms-transform: none !important;

--- a/assets/css/asianlegacylibrary/asianlegacylibrary.css
+++ b/assets/css/asianlegacylibrary/asianlegacylibrary.css
@@ -29,7 +29,7 @@ transform: translateX(0px) translateY(100vh) translateZ(0px) rotate(0deg) scale(
 .content-outer:not(.annual-report) 
 */
 
-.content-outer:not(.annual-content-holder) {
+.content-outer:not(:is(.annual-content-holder)) {
     -webkit-transform: none !important;
     -moz-transform: none !important;
     -ms-transform: none !important;


### PR DESCRIPTION
invalid selectors in the :not pseudo-class will break things, so added :not(:is(CLASS))
necessary for annual-report-2021 and timeline (history)